### PR TITLE
Add external agent fallback skill

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,6 +38,12 @@ Currently Dicio answers questions about:
 - **navigation**: opens the navigation app at the requested position - _Take me to New York, fifteenth avenue_
 - **media**: play, pause, previous, next song
 
+### External Agent Skill
+
+The optional external agent fallback lets you forward unmatched user queries to your own webhook (for example an n8n workflow).
+Open **Settings → External agent** to enter the webhook URL and, if required, an API key. When enabled, Dicio will POST the user
+text as JSON to the configured endpoint and speak the response.
+
 ## Speech to text
 
 Dicio uses [Vosk](https://github.com/alphacep/vosk-api/) as its speech to text (`STT`) engine. In order to be able to run on every phone small models are employed, weighing `~50MB`. The download from [here](https://alphacephei.com/vosk/models) starts automatically whenever needed, so the app language can be changed seamlessly.

--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -180,6 +180,7 @@ dependencies {
     // Miscellaneous
     implementation(libs.unbescape)
     implementation(libs.jsoup)
+    implementation(libs.androidx.preference)
 
     // Used by skills
     implementation(libs.exp4j)

--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -70,6 +70,11 @@
             android:exported="false" />
 
         <activity
+            android:name=".settings.SettingsActivity"
+            android:exported="false"
+            android:label="@string/pref_external_agent_category" />
+
+        <activity
             android:name=".io.input.stt_popup.SttPopupActivity"
             android:taskAffinity=""
             android:excludeFromRecents="true"

--- a/app/src/main/kotlin/org/stypox/dicio/eval/SkillHandler.kt
+++ b/app/src/main/kotlin/org/stypox/dicio/eval/SkillHandler.kt
@@ -19,6 +19,7 @@ import org.stypox.dicio.settings.datastore.UserSettings
 import org.stypox.dicio.settings.datastore.UserSettingsModule
 import org.stypox.dicio.skills.calculator.CalculatorInfo
 import org.stypox.dicio.skills.current_time.CurrentTimeInfo
+import org.stypox.dicio.skills.fallback.text.ExternalAgentInfo
 import org.stypox.dicio.skills.fallback.text.TextFallbackInfo
 import org.stypox.dicio.skills.listening.ListeningInfo
 import org.stypox.dicio.skills.lyrics.LyricsInfo
@@ -55,6 +56,7 @@ class SkillHandler @Inject constructor(
 
     // TODO add more fallback skills (e.g. search)
     private val fallbackSkillInfoList = listOf(
+        ExternalAgentInfo,
         TextFallbackInfo,
     )
 

--- a/app/src/main/kotlin/org/stypox/dicio/settings/MainSettingsScreen.kt
+++ b/app/src/main/kotlin/org/stypox/dicio/settings/MainSettingsScreen.kt
@@ -13,6 +13,7 @@ import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.automirrored.filled.ArrowBack
 import androidx.compose.material.icons.filled.DeleteSweep
 import androidx.compose.material.icons.filled.Extension
+import androidx.compose.material.icons.filled.SmartToy
 import androidx.compose.material.icons.filled.UploadFile
 import androidx.compose.material3.ExperimentalMaterial3Api
 import androidx.compose.material3.Icon
@@ -31,6 +32,8 @@ import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.dp
 import androidx.hilt.navigation.compose.hiltViewModel
+import androidx.compose.ui.platform.LocalContext
+import android.content.Intent
 import org.stypox.dicio.R
 import org.stypox.dicio.settings.datastore.InputDevice
 import org.stypox.dicio.settings.datastore.Language
@@ -196,6 +199,20 @@ private fun MainSettingsScreen(
 
         item {
             Spacer(modifier = Modifier.height(8.dp))
+        }
+
+        /* EXTERNAL AGENT */
+        item { SettingsCategoryTitle(stringResource(R.string.pref_external_agent_category)) }
+        item {
+            val context = LocalContext.current
+            SettingsItem(
+                title = stringResource(R.string.pref_external_agent_title),
+                icon = Icons.Default.SmartToy,
+                description = stringResource(R.string.pref_external_agent_summary),
+                modifier = Modifier.clickable {
+                    context.startActivity(Intent(context, SettingsActivity::class.java))
+                }
+            )
         }
     }
 }

--- a/app/src/main/kotlin/org/stypox/dicio/settings/SettingsActivity.kt
+++ b/app/src/main/kotlin/org/stypox/dicio/settings/SettingsActivity.kt
@@ -1,0 +1,25 @@
+package org.stypox.dicio.settings
+
+import android.os.Bundle
+import androidx.appcompat.app.AppCompatActivity
+import androidx.preference.PreferenceFragmentCompat
+import org.stypox.dicio.R
+
+class SettingsActivity : AppCompatActivity() {
+    override fun onCreate(savedInstanceState: Bundle?) {
+        super.onCreate(savedInstanceState)
+        title = getString(R.string.pref_external_agent_category)
+        if (savedInstanceState == null) {
+            supportFragmentManager
+                .beginTransaction()
+                .replace(android.R.id.content, ExternalAgentPreferencesFragment())
+                .commit()
+        }
+    }
+
+    class ExternalAgentPreferencesFragment : PreferenceFragmentCompat() {
+        override fun onCreatePreferences(savedInstanceState: Bundle?, rootKey: String?) {
+            setPreferencesFromResource(R.xml.preferences, rootKey)
+        }
+    }
+}

--- a/app/src/main/kotlin/org/stypox/dicio/skills/fallback/text/ExternalAgentInfo.kt
+++ b/app/src/main/kotlin/org/stypox/dicio/skills/fallback/text/ExternalAgentInfo.kt
@@ -1,0 +1,27 @@
+package org.stypox.dicio.skills.fallback.text
+
+import android.content.Context
+import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.filled.SmartToy
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.graphics.vector.rememberVectorPainter
+import org.dicio.skill.context.SkillContext
+import org.dicio.skill.skill.Skill
+import org.dicio.skill.skill.SkillInfo
+import org.stypox.dicio.R
+
+object ExternalAgentInfo : SkillInfo("external_agent") {
+    override fun name(context: Context) =
+        context.getString(R.string.skill_external_agent_name)
+
+    override fun sentenceExample(context: Context) = ""
+
+    @Composable
+    override fun icon() = rememberVectorPainter(Icons.Filled.SmartToy)
+
+    override fun isAvailable(ctx: SkillContext): Boolean = true
+
+    override fun build(ctx: SkillContext): Skill<*> {
+        return ExternalAgentSkill(this)
+    }
+}

--- a/app/src/main/kotlin/org/stypox/dicio/skills/fallback/text/ExternalAgentOutput.kt
+++ b/app/src/main/kotlin/org/stypox/dicio/skills/fallback/text/ExternalAgentOutput.kt
@@ -1,0 +1,21 @@
+package org.stypox.dicio.skills.fallback.text
+
+import androidx.compose.runtime.Composable
+import org.dicio.skill.context.SkillContext
+import org.dicio.skill.skill.InteractionPlan
+import org.dicio.skill.skill.SkillOutput
+import org.stypox.dicio.io.graphical.Headline
+
+data class ExternalAgentOutput(
+    val text: String,
+) : SkillOutput {
+    override fun getSpeechOutput(ctx: SkillContext): String = text
+
+    override fun getInteractionPlan(ctx: SkillContext): InteractionPlan =
+        InteractionPlan.FinishInteraction
+
+    @Composable
+    override fun GraphicalOutput(ctx: SkillContext) {
+        Headline(text = text)
+    }
+}

--- a/app/src/main/kotlin/org/stypox/dicio/skills/fallback/text/ExternalAgentSkill.kt
+++ b/app/src/main/kotlin/org/stypox/dicio/skills/fallback/text/ExternalAgentSkill.kt
@@ -1,0 +1,117 @@
+package org.stypox.dicio.skills.fallback.text
+
+import androidx.preference.PreferenceManager
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.withContext
+import okhttp3.MediaType.Companion.toMediaType
+import okhttp3.OkHttpClient
+import okhttp3.Request
+import okhttp3.RequestBody.Companion.toRequestBody
+import org.dicio.skill.context.SkillContext
+import org.dicio.skill.skill.SkillInfo
+import org.dicio.skill.skill.SkillOutput
+import org.json.JSONException
+import org.json.JSONObject
+import org.stypox.dicio.R
+import org.stypox.dicio.util.RecognizeEverythingSkill
+import org.stypox.dicio.util.getString
+import java.io.IOException
+
+class ExternalAgentSkill(correspondingSkillInfo: SkillInfo) :
+    RecognizeEverythingSkill(correspondingSkillInfo) {
+
+    override suspend fun generateOutput(ctx: SkillContext, inputData: String): SkillOutput {
+        val preferences = PreferenceManager.getDefaultSharedPreferences(ctx.android)
+        val url = preferences.getString(KEY_EXTERNAL_AGENT_URL, "")?.trim().orEmpty()
+        if (url.isBlank()) {
+            return ExternalAgentOutput(ctx.getString(R.string.external_agent_missing_url))
+        }
+        val apiKey =
+            preferences.getString(KEY_EXTERNAL_AGENT_API_KEY, "")?.trim().orEmpty()
+
+        return withContext(Dispatchers.IO) {
+            try {
+                val requestBody = JSONObject().apply {
+                    put("text", inputData)
+                }.toString().toRequestBody(JSON_MEDIA_TYPE)
+
+                val requestBuilder = Request.Builder()
+                    .url(url)
+                    .post(requestBody)
+                    .header("Content-Type", JSON_CONTENT_TYPE)
+
+                if (apiKey.isNotEmpty()) {
+                    requestBuilder.header("Authorization", "Bearer $apiKey")
+                }
+
+                httpClient.newCall(requestBuilder.build()).execute().use { response ->
+                    val body = response.body?.string().orEmpty()
+
+                    if (!response.isSuccessful) {
+                        return@withContext ExternalAgentOutput(
+                            ctx.getString(
+                                R.string.external_agent_http_error,
+                                response.code
+                            )
+                        )
+                    }
+
+                    if (body.isBlank()) {
+                        return@withContext ExternalAgentOutput(
+                            ctx.getString(R.string.external_agent_empty_response)
+                        )
+                    }
+
+                    val content = parseMessageContent(body)
+                        ?: return@withContext ExternalAgentOutput(
+                            ctx.getString(R.string.external_agent_invalid_response)
+                        )
+
+                    ExternalAgentOutput(content.trim())
+                }
+            } catch (exception: IOException) {
+                ExternalAgentOutput(
+                    ctx.getString(
+                        R.string.external_agent_request_failed,
+                        exception.localizedMessage ?: exception.javaClass.simpleName
+                    )
+                )
+            } catch (exception: JSONException) {
+                ExternalAgentOutput(
+                    ctx.getString(
+                        R.string.external_agent_invalid_response_with_reason,
+                        exception.localizedMessage ?: exception.javaClass.simpleName
+                    )
+                )
+            } catch (exception: IllegalArgumentException) {
+                ExternalAgentOutput(
+                    ctx.getString(
+                        R.string.external_agent_request_failed,
+                        exception.localizedMessage ?: exception.javaClass.simpleName
+                    )
+                )
+            }
+        }
+    }
+
+    private fun parseMessageContent(body: String): String? {
+        return try {
+            val json = JSONObject(body)
+            json.optJSONArray("choices")
+                ?.optJSONObject(0)
+                ?.optJSONObject("message")
+                ?.optString("content")
+                ?.takeIf { it.isNotBlank() }
+        } catch (_: JSONException) {
+            null
+        }
+    }
+
+    companion object {
+        private const val KEY_EXTERNAL_AGENT_URL = "external_agent_url"
+        private const val KEY_EXTERNAL_AGENT_API_KEY = "external_agent_api_key"
+        private const val JSON_CONTENT_TYPE = "application/json"
+        private val JSON_MEDIA_TYPE = "$JSON_CONTENT_TYPE; charset=utf-8".toMediaType()
+        private val httpClient = OkHttpClient()
+    }
+}

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -64,6 +64,13 @@
     <string name="pref_appearance">Appearance</string>
     <string name="pref_skills_title">Skills</string>
     <string name="pref_skills_summary">Enable/disable skills and tune their behavior</string>
+    <string name="pref_external_agent_category">External agent</string>
+    <string name="pref_external_agent_title">Configure external agent</string>
+    <string name="pref_external_agent_summary">Set the webhook URL and optional API key used by the external agent skill.</string>
+    <string name="pref_external_agent_url_title">Webhook URL</string>
+    <string name="pref_external_agent_url_summary">The HTTPS endpoint that receives user text as JSON.</string>
+    <string name="pref_external_agent_api_key_title">API key</string>
+    <string name="pref_external_agent_api_key_summary">Optional Bearer token that will be sent with the request.</string>
     <string name="expand">Expand</string>
     <string name="reduce">Reduce</string>
     <string name="pref_theme">Theme</string>
@@ -151,6 +158,7 @@
     <string name="skill_name_current_time">Current time</string>
     <string name="skill_sentence_example_current_time">What time is it?</string>
     <string name="skill_fallback_name_text">Text message</string>
+    <string name="skill_external_agent_name">External agent</string>
     <string name="skill_search_here_is_what_i_found">Here is what I found</string>
     <string name="skill_search_no_results">The search returned no results, try telling me again what you want to search for</string>
     <string name="skill_search_no_results_stop">The search returned no results</string>
@@ -233,4 +241,10 @@
     <string name="skill_weather_kelvin">K</string>
     <string name="skill_weather_meters_per_second">m/s</string>
     <string name="skill_weather_miles_per_hour">mph</string>
+    <string name="external_agent_missing_url">Configure the external agent URL in settings first.</string>
+    <string name="external_agent_request_failed">The external agent request failed: %1$s</string>
+    <string name="external_agent_http_error">External agent returned HTTP %1$d.</string>
+    <string name="external_agent_empty_response">External agent returned an empty response.</string>
+    <string name="external_agent_invalid_response">External agent returned an invalid response.</string>
+    <string name="external_agent_invalid_response_with_reason">External agent response could not be parsed: %1$s</string>
 </resources>

--- a/app/src/main/res/xml/preferences.xml
+++ b/app/src/main/res/xml/preferences.xml
@@ -1,0 +1,22 @@
+<?xml version="1.0" encoding="utf-8"?>
+<PreferenceScreen xmlns:android="http://schemas.android.com/apk/res/android">
+    <PreferenceCategory
+        android:key="external_agent_category"
+        android:title="@string/pref_external_agent_category">
+
+        <EditTextPreference
+            android:key="external_agent_url"
+            android:title="@string/pref_external_agent_url_title"
+            android:summary="@string/pref_external_agent_url_summary"
+            android:dialogTitle="@string/pref_external_agent_url_title"
+            android:inputType="textUri" />
+
+        <EditTextPreference
+            android:key="external_agent_api_key"
+            android:title="@string/pref_external_agent_api_key_title"
+            android:summary="@string/pref_external_agent_api_key_summary"
+            android:dialogTitle="@string/pref_external_agent_api_key_title"
+            android:inputType="textPassword"
+            android:useSimpleSummaryProvider="true" />
+    </PreferenceCategory>
+</PreferenceScreen>

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -31,6 +31,7 @@ unbescape = "1.1.6.RELEASE"
 voskAndroid = "0.3.32"
 litert = "1.1.2"
 permissionFlow = "2.0.0"
+preference = "1.2.1"
 
 [libraries]
 accompanist-drawablepainter = { module = "com.google.accompanist:accompanist-drawablepainter", version.ref = "accompanist" }
@@ -83,6 +84,7 @@ vosk-android = { module = "com.alphacephei:vosk-android", version.ref = "voskAnd
 litert = { module = "com.google.ai.edge.litert:litert", version.ref = "litert" }
 permission-flow-android = { module = "dev.shreyaspatil.permission-flow:permission-flow-android", version.ref = "permissionFlow" }
 permission-flow-compose = { module = "dev.shreyaspatil.permission-flow:permission-flow-compose", version.ref = "permissionFlow" }
+androidx-preference = { module = "androidx.preference:preference-ktx", version.ref = "preference" }
 
 [plugins]
 com-android-application = { id = "com.android.application", version.ref = "gradle" }


### PR DESCRIPTION
## Summary
- add an ExternalAgentSkill fallback that posts unmatched text to a configurable webhook and reads the OpenAI-style response
- wire up ExternalAgentOutput/Info, register the skill as the first fallback, and add preference-backed configuration
- surface External Agent settings in the UI with a dedicated category and document setup alongside the new dependency

## Testing
- ./gradlew :app:compileDebugKotlin *(fails: https://github.com/Stypox/dicio-numbers cannot open git-upload-pack in the offline environment)*

------
https://chatgpt.com/codex/tasks/task_b_68e56d0bdf2c8331a3b0dc21d1c91511