### PR TITLE
Add explicit androidx.preference dependency

### DIFF
--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -181,6 +181,7 @@ dependencies {
     implementation(libs.unbescape)
     implementation(libs.jsoup)
     implementation(libs.androidx.preference)
+    implementation("androidx.preference:preference:1.2.1")
 
     // Used by skills
     implementation(libs.exp4j)


### PR DESCRIPTION
## Summary
- add the core androidx.preference dependency at version 1.2.1 so that useSimpleSummaryProvider is available

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_b_68e5808069148331834e0a8674b38e21